### PR TITLE
[FEAT] when use JOIN command, send two more messages

### DIFF
--- a/includes/Message.hpp
+++ b/includes/Message.hpp
@@ -27,4 +27,6 @@
 #define MSGGREETING ":Welcome to IRC server\r\n"
 #define CODEGREET "001 "
 
+#define SERVNAME "irc.local "
+
 #endif /* __MESSAGE_HPP_ */

--- a/srcs/utils/Command.cpp
+++ b/srcs/utils/Command.cpp
@@ -50,9 +50,19 @@ void Join::run(int fd, std::vector<std::string> args) {
 			this->_handler.getServer().g_db.addChannelUser(curr_user, args[i]);
 			ChannelData chn = this->_handler.getServer().g_db.getCorrectChannel(args[i]);
 
-			buf = ":" + nick_name + MSGJOIN + args[i] + "\r\n";
-
+			// find the king in the channel
 			std::vector<std::string> user_list = chn.getUserList();
+			std::string king("");
+			for (size_t h = 0; h < user_list.size(); ++h) {
+				if (this->_handler.getServer().g_db.getCorrectChannel(args[i]).getPrivileges(user_list[h]) == 0) {
+					king = user_list[h];
+					break ;
+				}
+			}
+
+			buf = ":" + nick_name + MSGJOIN + args[i] + "\n"
+					+ ":" + SERVNAME	+ "353 " + nick_name + " = " + args[i] + " :@" + king + "\n"
+					+ ":" + SERVNAME + "366 " + nick_name + " " + args[i] + " :End of /NAMES list.\r\n";
 			int receiver(0);
 			for (size_t j = 0; j < user_list.size(); ++j) {
 				receiver = this->_handler.getServer().g_db.getUserTable().getUser(user_list[j]).fd;


### PR DESCRIPTION
- JOIN 커맨드를 사용하면 아래와같이 추가적으로 보내지는 두 줄의 메시지가 더 있습니다. 이를 추가해야 채널에 조인하고난 뒤 nc와 irssi 간에 메시지가 보이지 않는 현상이 해결됩니다!
- :irc.local 353 root = #123 :@root :irc.local 366 root #123 :End of /NAMES list.

- 우리 irc 서버에 맞춤화된 형식은 다음과 같습니다.
- :irc.local 353 <nickname> = <channel> :@<방장닉네임> :irc.local 366 <nickname> <channel> :End of /NAMES list.

RPL_NAMREPLY (353), RPL_ENDOFNAMES (366) RPL 메세지들은 채널에서 권한을 가진 사람이 누구인지 알려주고, 채널 리스트의 마지막을 알려줍니다