### PR TITLE
[FIX] seowokim-sigint_handler 처리

### DIFF
--- a/includes/Handler.hpp
+++ b/includes/Handler.hpp
@@ -19,7 +19,7 @@ private:
 
 	void figureCommand(int, std::pair<int, std::vector<std::string> >&);
 	bool servReceive(int);
-	void makeProtocol(int);
+	void signalQuit(int);
 };
 
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -28,6 +28,7 @@ class Server {
 		bool	getFdFlagsStatus(int, int);
 		bool	checkGreetingMessage(int);
 		void	removeFdFlags(int);
+		void	removeFdMessage(int);
 		Db	g_db;
 
 	private:

--- a/srcs/server/Server.cpp
+++ b/srcs/server/Server.cpp
@@ -117,3 +117,8 @@ void	Server::removeFdFlags(int fd)
 {
 	_fd_flags.erase(fd);
 }
+
+void	Server::removeFdMessage(int fd)
+{
+	_fd_message.erase(fd);
+}


### PR DESCRIPTION
- 클라이언트 Ctrl + C 종료시 해당 소켓 종료
- _fd_name_map, _fd_messsage, _fd_flags 삭제
- Handler에 signalQuit 멤버 함수로 통합